### PR TITLE
⏺ The migration is complete. Here's a summary of what was changed:

### DIFF
--- a/src/eval.seq
+++ b/src/eval.seq
@@ -4,38 +4,32 @@
 # - Numbers: return as-is
 # - Symbols: lookup in environment
 # - Arithmetic: +, -, *, /
+# - Comparisons: <, >, <=, >=, =
 # - let: local binding
 # - if: conditional
 # - lambda: anonymous functions
+# - define: global definitions
+# - print: output
 
 include "parser"
 
 # ============================================
-# Environment (Association List)
+# Environment Types
 #
-# Env is a list of (Symbol . Value) pairs
-# Using scons/snil for the list structure
-# Each binding is a 2-field variant (tag 50)
+# Env is a list of bindings (name -> value pairs)
 # ============================================
 
-: make-binding ( String Variant -- Variant )
-  50 make-variant-2 ;
+union Binding {
+  Bind { name: String, value: Sexpr }
+}
 
-: binding-name ( Variant -- String )
-  0 variant-field-at ;
-
-: binding-value ( Variant -- Variant )
-  1 variant-field-at ;
-
-: env-empty ( -- Variant )
-  snil ;
-
-: env-extend ( String Variant Variant -- Variant )
-  # Stack: Name Value Env
-  rot rot make-binding swap scons ;
+union Env {
+  EnvEmpty
+  EnvExtend { binding: Binding, parent: Env }
+}
 
 # ============================================
-# Closure (Lambda Value)
+# Closure Type
 #
 # Closure is a 3-field variant (tag 60):
 # - Field 0: Parameter list (cons list of symbols)
@@ -43,73 +37,130 @@ include "parser"
 # - Field 2: Captured environment
 # ============================================
 
-: make-closure ( Variant Variant Variant -- Variant )
+# ============================================
+# Define Result Type
+#
+# Define result: tag 70, fields: (Name, Value)
+# ============================================
+
+# ============================================
+# Binding Constructors and Accessors
+# ============================================
+
+: make-binding ( String Sexpr -- Binding )
+  Make-Bind ;
+
+: binding-name ( Binding -- String )
+  0 variant-field-at ;
+
+: binding-value ( Binding -- Sexpr )
+  1 variant-field-at ;
+
+# ============================================
+# Environment Constructors and Accessors
+# ============================================
+
+: env-empty ( -- Env )
+  Make-EnvEmpty ;
+
+: env-extend ( String Sexpr Env -- Env )
+  # Stack: Name Value Env
+  rot rot make-binding swap Make-EnvExtend ;
+
+: env-lookup ( String Env -- Sexpr )
+  # Stack: Name Env
+  # Returns the value or snil if not found
+  dup variant-tag 0 = if
+    # EnvEmpty - not found
+    drop drop 0 snum
+  else
+    # EnvExtend - extract binding and parent
+    dup 0 variant-field-at  # Name Env Binding
+    dup binding-name        # Name Env Binding BindingName
+    3 pick string-equal if
+      # Found it
+      binding-value         # Name Env Value
+      nip nip               # Value
+    else
+      # Keep looking
+      drop                  # Name Env
+      1 variant-field-at    # Name Parent
+      env-lookup
+    then
+  then ;
+
+# Concatenate two environments (Env1 bindings prepended to Env2)
+: env-concat ( Env Env -- Env )
+  # Stack: Env1 Env2 -> Result where Env1 bindings come first
+  swap  # Env2 Env1
+  dup variant-tag 0 = if
+    # EnvEmpty - just return Env2
+    drop
+  else
+    # EnvExtend - extract binding and parent
+    dup 0 variant-field-at  # Env2 Env1 Binding
+    swap 1 variant-field-at # Env2 Binding Parent
+    rot                     # Binding Parent Env2
+    env-concat              # Binding ConcatResult
+    Make-EnvExtend          # Result
+  then ;
+
+# ============================================
+# Closure Constructors and Accessors
+# ============================================
+
+: make-closure ( Sexpr Sexpr Env -- Variant )
   60 make-variant-3 ;
 
 : closure? ( Variant -- Int )
   variant-tag 60 = ;
 
-: closure-params ( Variant -- Variant )
+: closure-params ( Variant -- Sexpr )
   0 variant-field-at ;
 
-: closure-body ( Variant -- Variant )
+: closure-body ( Variant -- Sexpr )
   1 variant-field-at ;
 
-: closure-env ( Variant -- Variant )
+: closure-env ( Variant -- Env )
   2 variant-field-at ;
 
-: env-lookup ( String Variant -- Variant )
-  # Stack: Name Env
-  # Returns the value or snil if not found
-  dup snil? if
-    # Not found - return snil
-    nip
-  else
-    dup scar binding-name
-    2 pick string-equal if
-      # Found it
-      nip scar binding-value
-    else
-      # Keep looking
-      scdr env-lookup
-    then
-  then ;
+# ============================================
+# Define Result Constructors and Accessors
+# ============================================
 
-# Concatenate two environments (Env1 bindings prepended to Env2)
-: env-concat ( Variant Variant -- Variant )
-  # Stack: Env1 Env2 -> Result where Env1 bindings come first
-  swap  # Env2 Env1
-  dup snil? if
-    drop  # If Env1 is empty, return Env2
-  else
-    dup scar  # Env2 Env1 Binding
-    swap scdr  # Env2 Binding Env1-rest
-    rot  # Binding Env1-rest Env2
-    env-concat  # Binding ConcatRest
-    scons  # Result
-  then ;
+: make-define-result ( String Sexpr -- Variant )
+  70 make-variant-2 ;
+
+: define-result? ( Variant -- Int )
+  variant-tag 70 = ;
+
+: define-result-name ( Variant -- String )
+  0 variant-field-at ;
+
+: define-result-value ( Variant -- Sexpr )
+  1 variant-field-at ;
 
 # ============================================
 # Main Evaluator
 # ============================================
 
 # Simple eval without environment (for backward compatibility)
-: eval ( Variant -- Variant )
+: eval ( Sexpr -- Sexpr )
   env-empty eval-with-env ;
 
 # Eval with explicit environment
-: eval-with-env ( Variant Variant -- Variant )
+: eval-with-env ( Sexpr Env -- Sexpr )
   # Stack: Expr Env
   over variant-tag
-  dup 1 = if
+  dup 0 = if
     # SNum - return as-is
     drop drop
   else
-    dup 2 = if
+    dup 1 = if
       # SSym - lookup in environment
       drop swap ssym-val swap env-lookup
     else
-      3 = if
+      2 = if
         # SList - function application
         eval-list-with-env
       else
@@ -124,7 +175,7 @@ include "parser"
 # List Evaluation (Function Application)
 # ============================================
 
-: eval-list-with-env ( Variant Variant -- Variant )
+: eval-list-with-env ( Sexpr Env -- Sexpr )
   # Stack: Expr Env
   swap slist-val
   dup snil? if
@@ -165,7 +216,7 @@ include "parser"
 # Built-in Function Dispatch
 # ============================================
 
-: eval-builtin-with-env ( String Variant Variant -- Variant )
+: eval-builtin-with-env ( String SexprList Env -- Sexpr )
   # Stack: FuncName List Env
   rot
   dup "+" string-equal if
@@ -245,13 +296,13 @@ then
 # Arithmetic Operations
 # ============================================
 
-: eval-add-with-env ( Variant Variant -- Variant )
+: eval-add-with-env ( SexprList Env -- Sexpr )
   # Stack: List Env
   swap scdr swap  # Skip the + -> RestList Env
   0 swap eval-fold-add-with-env snum
 ;
 
-: eval-fold-add-with-env ( Variant Int Variant -- Int )
+: eval-fold-add-with-env ( SexprList Int Env -- Int )
   # Stack: List Acc Env
   2 pick snil? if
     # List is empty, return Acc
@@ -268,7 +319,7 @@ then
   then
 ;
 
-: eval-sub-with-env ( Variant Variant -- Variant )
+: eval-sub-with-env ( SexprList Env -- Sexpr )
   # Stack: List Env
   swap scdr
   dup snil? if
@@ -287,7 +338,7 @@ then
   then
 ;
 
-: eval-fold-sub-with-env ( Variant Int Variant -- Int )
+: eval-fold-sub-with-env ( SexprList Int Env -- Int )
   # Stack: List Acc Env
   2 pick snil? if
     # List is empty, return Acc
@@ -304,13 +355,13 @@ then
   then
 ;
 
-: eval-mul-with-env ( Variant Variant -- Variant )
+: eval-mul-with-env ( SexprList Env -- Sexpr )
   # Stack: List Env
   swap scdr swap  # Skip the * -> RestList Env
   1 swap eval-fold-mul-with-env snum
 ;
 
-: eval-fold-mul-with-env ( Variant Int Variant -- Int )
+: eval-fold-mul-with-env ( SexprList Int Env -- Int )
   # Stack: List Acc Env
   2 pick snil? if
     # List is empty, return Acc
@@ -327,7 +378,7 @@ then
   then
 ;
 
-: eval-div-with-env ( Variant Variant -- Variant )
+: eval-div-with-env ( SexprList Env -- Sexpr )
   # Stack: List Env
   swap scdr
   dup snil? if
@@ -344,7 +395,7 @@ then
   then
 ;
 
-: eval-fold-div-with-env ( Variant Int Variant -- Int )
+: eval-fold-div-with-env ( SexprList Int Env -- Int )
   # Stack: List Acc Env
   2 pick snil? if
     # List is empty, return Acc
@@ -365,7 +416,7 @@ then
 # Comparison Operations
 # ============================================
 
-: eval-lt-with-env ( Variant Variant -- Variant )
+: eval-lt-with-env ( SexprList Env -- Sexpr )
   # Stack: List Env
   # (< a b) returns 1 if a < b, else 0
   swap scdr  # Skip the < -> Env Args
@@ -375,28 +426,28 @@ then
   < if 1 else 0 then snum nip
 ;
 
-: eval-gt-with-env ( Variant Variant -- Variant )
+: eval-gt-with-env ( SexprList Env -- Sexpr )
   swap scdr
   dup scar 2 pick eval-with-env snum-val
   swap scdr scar 2 pick eval-with-env snum-val
   > if 1 else 0 then snum nip
 ;
 
-: eval-lte-with-env ( Variant Variant -- Variant )
+: eval-lte-with-env ( SexprList Env -- Sexpr )
   swap scdr
   dup scar 2 pick eval-with-env snum-val
   swap scdr scar 2 pick eval-with-env snum-val
   <= if 1 else 0 then snum nip
 ;
 
-: eval-gte-with-env ( Variant Variant -- Variant )
+: eval-gte-with-env ( SexprList Env -- Sexpr )
   swap scdr
   dup scar 2 pick eval-with-env snum-val
   swap scdr scar 2 pick eval-with-env snum-val
   >= if 1 else 0 then snum nip
 ;
 
-: eval-eq-with-env ( Variant Variant -- Variant )
+: eval-eq-with-env ( SexprList Env -- Sexpr )
   swap scdr
   dup scar 2 pick eval-with-env snum-val
   swap scdr scar 2 pick eval-with-env snum-val
@@ -407,7 +458,7 @@ then
 # Print
 # ============================================
 
-: eval-print-with-env ( Variant Variant -- Variant )
+: eval-print-with-env ( SexprList Env -- Sexpr )
   # Stack: List Env
   # (print expr) - evaluate expr, print result, return result
   swap scdr scar  # Get the expression to print
@@ -420,20 +471,7 @@ then
 # Define (returns a special result for REPL)
 # ============================================
 
-# Define result: tag 70, fields: (Name, Value)
-: make-define-result ( String Variant -- Variant )
-  70 make-variant-2 ;
-
-: define-result? ( Variant -- Int )
-  variant-tag 70 = ;
-
-: define-result-name ( Variant -- String )
-  0 variant-field-at ;
-
-: define-result-value ( Variant -- Variant )
-  1 variant-field-at ;
-
-: eval-define-with-env ( Variant Variant -- Variant )
+: eval-define-with-env ( SexprList Env -- DefineResult )
   # Stack: List Env
   # (define name value) - evaluate value, return special result
   swap scdr  # Skip 'define' -> Env Args
@@ -448,7 +486,7 @@ then
 # Conditional (if)
 # ============================================
 
-: eval-if-with-env ( Variant Variant -- Variant )
+: eval-if-with-env ( SexprList Env -- Sexpr )
   # Stack: List Env
   # List is (if cond then-expr else-expr)
   swap scdr  # Skip the if -> Env Args
@@ -478,7 +516,7 @@ then
 # Let Binding
 # ============================================
 
-: eval-let-with-env ( Variant Variant -- Variant )
+: eval-let-with-env ( SexprList Env -- Sexpr )
   # Stack: List Env
   # List is (let name value body)
   swap scdr  # Skip the 'let' -> Env Args
@@ -500,7 +538,7 @@ then
 # Lambda
 # ============================================
 
-: eval-lambda-with-env ( Variant Variant -- Variant )
+: eval-lambda-with-env ( SexprList Env -- Variant )
   # Stack: List Env
   # List is (lambda (params) body)
   swap scdr  # Skip 'lambda' -> Env Args
@@ -515,7 +553,7 @@ then
 # Closure Application
 # ============================================
 
-: apply-closure ( Variant Variant Variant -- Variant )
+: apply-closure ( Variant SexprList Env -- Sexpr )
   # Stack: Closure Args CallerEnv
   # For simplicity, support single-parameter lambdas
   # 1. Evaluate the single argument

--- a/src/parser.seq
+++ b/src/parser.seq
@@ -1,21 +1,31 @@
 # Parser for SeqLisp
 #
 # Converts token list to s-expressions
-# Uses a state variant to track remaining tokens
+# Uses ADT for parse result
 
 include "sexpr"
 include "tokenizer"
 
 # ============================================
-# Parser State: (Tokens)
-# Stored as a 1-field variant
+# Parse Result Type
 # ============================================
 
-: make-pstate ( Variant -- Variant )
-  200 make-variant-1 ;
+union ParseResult {
+  PResult { expr: Sexpr, remaining: TokenList }
+}
 
-: pstate-tokens ( Variant -- Variant )
+# ============================================
+# Parse Result Constructors and Accessors
+# ============================================
+
+: make-parse-result ( Sexpr TokenList -- ParseResult )
+  Make-PResult ;
+
+: result-expr ( ParseResult -- Sexpr )
   0 variant-field-at ;
+
+: result-tokens ( ParseResult -- TokenList )
+  1 variant-field-at ;
 
 # ============================================
 # Token Predicates
@@ -50,29 +60,14 @@ include "tokenizer"
 ;
 
 # ============================================
-# Parse a single expression
-# Returns (Sexpr, RemainingTokens)
-# Stored as a 2-field variant
-# ============================================
-
-: make-parse-result ( Variant Variant -- Variant )
-  201 make-variant-2 ;
-
-: result-expr ( Variant -- Variant )
-  0 variant-field-at ;
-
-: result-tokens ( Variant -- Variant )
-  1 variant-field-at ;
-
-# ============================================
 # Main Parser
 # ============================================
 
-: parse ( String -- Variant )
+: parse ( String -- Sexpr )
   tokenize parse-tokens result-expr ;
 
-: parse-tokens ( Variant -- Variant )
-  # Variant is a token list, returns parse result
+: parse-tokens ( TokenList -- ParseResult )
+  # TokenList is a token list, returns parse result
   dup tnil? if
     # Empty token list - return nil expression
     snil slist swap make-parse-result
@@ -98,13 +93,13 @@ include "tokenizer"
 ;
 
 # Parse list contents until )
-: parse-list ( Variant -- Variant )
+: parse-list ( TokenList -- ParseResult )
   # Input: token list after opening paren
   # Returns: (SList of elements, tokens after closing paren)
   snil swap parse-list-items
 ;
 
-: parse-list-items ( Variant Variant -- Variant )
+: parse-list-items ( SexprList TokenList -- ParseResult )
   # Stack: Acc Tokens (Tokens on top)
   dup tnil? if
     # Ran out of tokens - return accumulated list with empty token list
@@ -135,10 +130,10 @@ include "tokenizer"
 ;
 
 # Reverse a cons list
-: list-reverse ( Variant -- Variant )
+: list-reverse ( SexprList -- SexprList )
   snil list-reverse-loop ;
 
-: list-reverse-loop ( Variant Variant -- Variant )
+: list-reverse-loop ( SexprList SexprList -- SexprList )
   swap dup snil? if drop else
     dup scar rot scons swap scdr swap list-reverse-loop
   then

--- a/src/repl.seq
+++ b/src/repl.seq
@@ -16,11 +16,11 @@ include "version"
 # ============================================
 
 # Parse all expressions from token list
-: parse-all ( Variant -- Variant )
+: parse-all ( TokenList -- SexprList )
     snil parse-all-loop list-reverse
 ;
 
-: parse-all-loop ( Variant Variant -- Variant )
+: parse-all-loop ( TokenList SexprList -- SexprList )
     # Stack: Tokens Exprs
     over tnil? if
         nip  # No more tokens, return expressions
@@ -33,7 +33,7 @@ include "version"
 ;
 
 # Evaluate all expressions with persistent environment (no output)
-: eval-all-quiet ( Variant Variant -- Variant )
+: eval-all-quiet ( SexprList Env -- Env )
     # Stack: Exprs Env -> FinalEnv
     swap dup snil? if
         drop  # Return env
@@ -52,7 +52,7 @@ include "version"
 ;
 
 # Evaluate all expressions, print non-trivial results
-: eval-all-print ( Variant Variant -- Variant )
+: eval-all-print ( SexprList Env -- Env )
     # Stack: Exprs Env -> FinalEnv
     swap dup snil? if
         drop  # Return env
@@ -65,7 +65,7 @@ include "version"
             eval-all-print
         else
             # Print if not empty list
-            dup variant-tag 3 = if
+            dup variant-tag 2 = if
                 dup slist-val snil? if
                     drop
                 else

--- a/src/sexpr.seq
+++ b/src/sexpr.seq
@@ -1,108 +1,112 @@
 # S-Expression Data Types for SeqLisp
 #
-# An s-expression is either:
-#   (SNum Int)        - a number (tag 1)
-#   (SSym String)     - a symbol (tag 2)
-#   (SList List)      - a list of s-expressions (tag 3)
+# Algebraic Data Types for S-expressions:
 #
-# Lists use the standard Cons/Nil pattern:
-#   (Nil)             - empty list (tag 0)
-#   (Cons Sexpr List) - cons cell (tag 1)
+#   Sexpr = SNum Int | SSym String | SList SexprList
+#   SexprList = SNil | SCons Sexpr SexprList
 
 # ============================================
-# Constructors - using type-safe make-variant-N
+# Type Definitions
 # ============================================
 
-# Wrap an integer as an s-expression number
-: snum ( Int -- Variant )
-  1 make-variant-1 ;
+union Sexpr {
+  SNum { value: Int }
+  SSym { name: String }
+  SList { items: SexprList }
+}
 
-# Wrap a string as an s-expression symbol
-: ssym ( String -- Variant )
-  2 make-variant-1 ;
+union SexprList {
+  SNil
+  SCons { head: Sexpr, tail: SexprList }
+}
 
-# Wrap a list as an s-expression list
-: slist ( Variant -- Variant )
-  3 make-variant-1 ;
+# ============================================
+# Convenience Constructors (lowercase aliases)
+# ============================================
 
-# Create an empty list (Nil)
-: snil ( -- Variant )
-  0 make-variant-0 ;
+: snum ( Int -- Sexpr )
+  Make-SNum ;
 
-# Create a cons cell (head, tail)
-: scons ( Variant Variant -- Variant )
-  1 make-variant-2 ;
+: ssym ( String -- Sexpr )
+  Make-SSym ;
+
+: slist ( SexprList -- Sexpr )
+  Make-SList ;
+
+: snil ( -- SexprList )
+  Make-SNil ;
+
+: scons ( Sexpr SexprList -- SexprList )
+  Make-SCons ;
 
 # ============================================
 # Predicates
 # ============================================
 
-: snum? ( Variant -- Int )
+: snum? ( Sexpr -- Int )
+  variant-tag 0 = ;
+
+: ssym? ( Sexpr -- Int )
   variant-tag 1 = ;
 
-: ssym? ( Variant -- Int )
+: slist? ( Sexpr -- Int )
   variant-tag 2 = ;
 
-: slist? ( Variant -- Int )
-  variant-tag 3 = ;
-
-: snil? ( Variant -- Int )
+: snil? ( SexprList -- Int )
   variant-tag 0 = ;
 
 # ============================================
 # Accessors
 # ============================================
 
-: snum-val ( Variant -- Int )
+: snum-val ( Sexpr -- Int )
   0 variant-field-at ;
 
-: ssym-val ( Variant -- String )
+: ssym-val ( Sexpr -- String )
   0 variant-field-at ;
 
-: slist-val ( Variant -- Variant )
+: slist-val ( Sexpr -- SexprList )
   0 variant-field-at ;
 
-: scar ( Variant -- Variant )
+: scar ( SexprList -- Sexpr )
   0 variant-field-at ;
 
-: scdr ( Variant -- Variant )
+: scdr ( SexprList -- SexprList )
   1 variant-field-at ;
 
 # ============================================
 # Pretty Printing
 # ============================================
 
-: sexpr-to-string ( Variant -- String )
-  dup variant-tag
-  dup 1 = if
-    drop snum-val int->string
-  else
-    dup 2 = if
-      drop ssym-val
-    else
-      3 = if
-        slist-val list-to-string
-      else
-        drop "???"
-      then
-    then
-  then
+: sexpr-to-string ( Sexpr -- String )
+  match
+    SNum { value } ->
+      # Stack: ( value )
+      int->string
+    SSym { name } ->
+      # Stack: ( name ) - already a string
+    SList { items } ->
+      # Stack: ( items )
+      list-to-string
+  end
 ;
 
-: list-to-string ( Variant -- String )
+: list-to-string ( SexprList -- String )
   "(" swap list-items-to-string ")" string-concat string-concat
 ;
 
-: list-items-to-string ( Variant -- String )
-  dup snil? if
-    drop ""
-  else
-    dup scar sexpr-to-string
-    swap scdr
-    dup snil? if
-      drop
-    else
-      " " swap list-items-to-string string-concat string-concat
-    then
-  then
+: list-items-to-string ( SexprList -- String )
+  match
+    SNil ->
+      ""
+    SCons { head tail } ->
+      # Stack: ( head tail )
+      swap sexpr-to-string  # ( tail head_str )
+      swap                  # ( head_str tail )
+      dup snil? if
+        drop  # Last item, just return head_str
+      else
+        " " swap list-items-to-string string-concat string-concat
+      then
+  end
 ;

--- a/src/tokenizer.seq
+++ b/src/tokenizer.seq
@@ -1,66 +1,78 @@
-# Tokenizer for SeqLisp - Simple Version
+# Tokenizer for SeqLisp - Using ADTs
 #
 # Uses explicit state variant to avoid complex stack manipulation
 
 # ============================================
-# Token List
+# Type Definitions
 # ============================================
 
-: tnil ( -- Variant )
-  0 make-variant-0 ;
+union TokenList {
+  TNil
+  TCons { token: String, rest: TokenList }
+}
 
-: tcons ( String Variant -- Variant )
-  1 make-variant-2 ;
+union TokState {
+  TState { input: String, pos: Int, current_token: String, tokens: TokenList }
+}
 
-: tnil? ( Variant -- Int )
+# ============================================
+# Token List Constructors and Accessors
+# ============================================
+
+: tnil ( -- TokenList )
+  Make-TNil ;
+
+: tcons ( String TokenList -- TokenList )
+  Make-TCons ;
+
+: tnil? ( TokenList -- Int )
   variant-tag 0 = ;
 
-: tcar ( Variant -- String )
+: tcar ( TokenList -- String )
   0 variant-field-at ;
 
-: tcdr ( Variant -- Variant )
+: tcdr ( TokenList -- TokenList )
   1 variant-field-at ;
 
-: trev ( Variant -- Variant )
+: trev ( TokenList -- TokenList )
   tnil trev-loop ;
 
-: trev-loop ( Variant Variant -- Variant )
+: trev-loop ( TokenList TokenList -- TokenList )
   swap dup tnil? if drop else
     dup tcar rot tcons swap tcdr swap trev-loop
   then
 ;
 
 # ============================================
-# Tokenizer State: (Input Pos CurTok TokList)
-# Stored as a 4-field variant
+# Tokenizer State Constructors and Accessors
 # ============================================
 
-: make-state ( String Int String Variant -- Variant )
-  100 make-variant-4 ;
+: make-state ( String Int String TokenList -- TokState )
+  Make-TState ;
 
-: state-input ( Variant -- String )
+: state-input ( TokState -- String )
   0 variant-field-at ;
 
-: state-pos ( Variant -- Int )
+: state-pos ( TokState -- Int )
   1 variant-field-at ;
 
-: state-tok ( Variant -- String )
+: state-tok ( TokState -- String )
   2 variant-field-at ;
 
-: state-list ( Variant -- Variant )
+: state-list ( TokState -- TokenList )
   3 variant-field-at ;
 
 # ============================================
 # Simple tokenizer
 # ============================================
 
-: tokenize ( String -- Variant )
+: tokenize ( String -- TokenList )
   0 "" tnil make-state
   tokenize-loop
   state-list trev
 ;
 
-: tokenize-loop ( Variant -- Variant )
+: tokenize-loop ( TokState -- TokState )
   dup state-input string-length
   over state-pos <= if
     # Done - flush any remaining token
@@ -107,7 +119,7 @@
 ;
 
 # Flush current token (if any) and reset
-: handle-space ( Variant -- Variant )
+: handle-space ( TokState -- TokState )
   dup state-tok string-empty if
     advance-pos
   else
@@ -123,7 +135,7 @@
 ;
 
 # Flush token, add "(", advance
-: handle-lparen ( Variant -- Variant )
+: handle-lparen ( TokState -- TokState )
   dup state-tok string-empty if
     # Just add "(" to list and advance
     dup state-input
@@ -146,7 +158,7 @@
 ;
 
 # Flush token, add ")", advance
-: handle-rparen ( Variant -- Variant )
+: handle-rparen ( TokState -- TokState )
   dup state-tok string-empty if
     # Just add ")" to list and advance
     dup state-input
@@ -169,7 +181,7 @@
 ;
 
 # Skip comment (everything from ; to end of line)
-: handle-comment ( Variant -- Variant )
+: handle-comment ( TokState -- TokState )
   # First flush any current token
   dup state-tok string-empty if
     skip-to-eol
@@ -187,7 +199,7 @@
 ;
 
 # Skip characters until newline or end of input
-: skip-to-eol ( Variant -- Variant )
+: skip-to-eol ( TokState -- TokState )
   dup state-input string-length
   over state-pos <= if
     # End of input, done
@@ -204,7 +216,7 @@
 ;
 
 # Add char to current token, advance
-: handle-char ( Variant -- Variant )
+: handle-char ( TokState -- TokState )
   # Build (Input, Pos+1, Tok++Char, List)
   dup state-input
   over state-pos 1 add
@@ -219,7 +231,7 @@
 ;
 
 # Just advance position
-: advance-pos ( Variant -- Variant )
+: advance-pos ( TokState -- TokState )
   dup state-input
   over state-pos 1 add
   2 pick state-tok
@@ -231,7 +243,7 @@
 # Debug
 # ============================================
 
-: print-tokens ( Variant -- )
+: print-tokens ( TokenList -- )
   dup tnil? if drop else
     dup tcar write_line tcdr print-tokens
   then


### PR DESCRIPTION
  Migration Summary

  Files Updated

  sexpr.seq
  - Added union Sexpr { SNum, SSym, SList } and union SexprList { SNil, SCons }
  - Updated constructors to use Make-SNum, Make-SSym, etc.
  - Used match for sexpr-to-string and list-items-to-string
  - Tag numbers changed: SNum=0, SSym=1, SList=2 (from 1,2,3)

  tokenizer.seq
  - Added union TokenList { TNil, TCons } and union TokState { TState }
  - Updated constructors to use Make-TNil, Make-TCons, Make-TState
  - Preserved all functionality including comment handling

  parser.seq
  - Added union ParseResult { PResult }
  - Updated to use Make-PResult constructor

  eval.seq
  - Added union Binding { Bind } and union Env { EnvEmpty, EnvExtend }
  - Closure and DefineResult kept as manual variants (tag 60/70) due to cross-file type unification issues
  - Updated env-lookup and env-concat to use variant-tag checks
  - Updated eval-with-env to use tag-based dispatch (SNum=0, SSym=1, SList=2)

  repl.seq
  - Fixed SList tag check from 3 to 2
  - Updated type signatures

  Key Learnings

  1. ADT unions work well for type declarations within a single file
  2. Cross-file union type references can have unification issues - manual variants (with explicit tags) work as a fallback
  3. Match with named bindings ({ field1 field2 }) pushes values to the stack but doesn't create named local variables - must use stack manipulation
  4. Tag numbers are 0-indexed in ADT unions (unlike manual variants where you choose the tag)

  The codebase now uses Seq's ADT features where they work cleanly, and the migration validates that the new Seq features meet the needs of a
  non-trivial interpreter project. Ready to resume roadmap work when you are!