### PR TITLE
The quote and ' syntax implementation is complete.

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,7 +33,7 @@ A working interpreter with:
 - [ ] Command history (if Seq gets readline support)
 
 ### Core Lisp Features
-- [ ] `quote` and `'` syntax
+- [x] `quote` and `'` syntax
 - [ ] List operations: `cons`, `car`, `cdr`, `list`
 - [ ] Predicates: `null?`, `number?`, `symbol?`, `list?`
 - [ ] Boolean literals: `#t`, `#f` (or `true`, `false`)

--- a/src/eval.seq
+++ b/src/eval.seq
@@ -264,6 +264,9 @@ union LispClosure {
                           dup "define" string-equal if
                             drop eval-define-with-env
                           else
+                            dup "quote" string-equal if
+                              drop eval-quote-with-env
+                            else
                             # Unknown function - look up in environment
                             # Stack: List Env FuncName
                             over  # List Env FuncName Env
@@ -278,6 +281,7 @@ union LispClosure {
                             else
                               # Not a closure, return as list
                               drop drop slist
+                            then
                             then
                           then
                         then
@@ -483,6 +487,17 @@ then
   rot  # -> Name ValueExpr Env
   eval-with-env  # Evaluate value -> Name Value
   make-define-result  # Return (Name, Value) tagged result
+;
+
+# ============================================
+# Quote (returns argument unevaluated)
+# ============================================
+
+: eval-quote-with-env ( SexprList Env -- Sexpr )
+  # Stack: List Env
+  # (quote expr) - return expr without evaluating
+  drop  # Drop environment, not needed
+  scdr scar  # Skip 'quote', get the expression
 ;
 
 # ============================================

--- a/src/parser.seq
+++ b/src/parser.seq
@@ -37,6 +37,9 @@ union ParseResult {
 : is-rparen ( String -- Int )
   ")" string-equal ;
 
+: is-quote ( String -- Int )
+  "'" string-equal ;
+
 : is-digit ( Int -- Int )
   dup 48 >= swap 57 <= and ;
 
@@ -81,15 +84,34 @@ union ParseResult {
         # Unexpected ) - error, just skip
         drop tcdr parse-tokens
       else
-        # Atom (number or symbol)
-        dup is-number-token if
-          string->int drop snum swap tcdr make-parse-result
+        dup is-quote if
+          # Quote: 'expr -> (quote expr)
+          drop tcdr parse-quote
         else
-          ssym swap tcdr make-parse-result
+          # Atom (number or symbol)
+          dup is-number-token if
+            string->int drop snum swap tcdr make-parse-result
+          else
+            ssym swap tcdr make-parse-result
+          then
         then
       then
     then
   then
+;
+
+# Parse quote: expand 'expr to (quote expr)
+: parse-quote ( TokenList -- ParseResult )
+  # Parse the next expression
+  parse-tokens
+  # Stack: ParseResult
+  dup result-expr   # ParseResult Expr
+  swap result-tokens  # Expr RemTokens
+  # Build (quote expr) -> SList of (SSym "quote", expr)
+  swap snil scons  # RemTokens (expr)
+  "quote" ssym swap scons  # RemTokens (quote expr)
+  slist  # RemTokens SList
+  swap make-parse-result
 ;
 
 # Parse list contents until )

--- a/src/test_eval.seq
+++ b/src/test_eval.seq
@@ -44,4 +44,9 @@ include "eval"
 
   # Closure capturing environment
   "(let y 10 ((lambda (x) (+ x y)) 5))" eval-print
+
+  # Quote - returns unevaluated
+  "'x" eval-print
+  "'(1 2 3)" eval-print
+  "(quote (+ 1 2))" eval-print
 ;

--- a/src/test_parser.seq
+++ b/src/test_parser.seq
@@ -19,4 +19,8 @@ include "parser"
 
   # More complex
   "(if (> x 0) 1 -1)" print-parse
+
+  # Quote syntax
+  "'x" print-parse
+  "'(1 2 3)" print-parse
 ;

--- a/src/tokenizer.seq
+++ b/src/tokenizer.seq
@@ -105,12 +105,17 @@ union TokState {
           # Left paren
           drop handle-lparen tokenize-loop
         else
-          41 = if
+          dup 41 = if
             # Right paren
-            handle-rparen tokenize-loop
+            drop handle-rparen tokenize-loop
           else
-            # Regular char
-            handle-char tokenize-loop
+            39 = if
+              # Single quote - emit as its own token
+              handle-quote tokenize-loop
+            else
+              # Regular char
+              handle-char tokenize-loop
+            then
           then
         then
       then
@@ -175,6 +180,29 @@ union TokState {
     3 pick state-tok
     swap tcons
     ")" swap tcons
+    "" swap
+    make-state nip
+  then
+;
+
+# Flush token, add "'", advance
+: handle-quote ( TokState -- TokState )
+  dup state-tok string-empty if
+    # Just add "'" to list and advance
+    dup state-input
+    over state-pos 1 add
+    2 pick state-list
+    "'" swap tcons
+    "" swap
+    make-state nip
+  else
+    # Flush token, then add "'"
+    dup state-input
+    over state-pos 1 add
+    2 pick state-list
+    3 pick state-tok
+    swap tcons
+    "'" swap tcons
     "" swap
     make-state nip
   then


### PR DESCRIPTION
Here's a summary of the changes:

  tokenizer.seq (previously done):
  - Added handling for ' (ASCII 39) as a standalone token
  - Added handle-quote function to emit ' as its own token

  parser.seq:
  - Added is-quote predicate to recognize the ' token
  - Added parse-quote function that expands 'expr to (quote expr)
  - Updated parse-tokens to route ' tokens to parse-quote

  eval.seq:
  - Added quote to the builtin dispatch
  - Added eval-quote-with-env function that returns its argument unevaluated

  test_parser.seq and test_eval.seq:
  - Added tests for quote syntax

  docs/ROADMAP.md:
  - Checked off quote and ' syntax as complete

  All tests pass. The feature works for both the shorthand 'expr and the explicit (quote expr) forms.