### PR TITLE
lineno in errors

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -86,6 +86,10 @@ The current architecture is sound for adding comprehensive error handling. No fu
   - Tokenizer tracks positions for all tokens
   - Parser propagates spans to S-expressions
   - Evaluator includes spans in EvalErr for LSP diagnostics
+- [x] Error messages display line/column information
+  - Format: `Error [line:col]: message` when span is available
+  - Falls back to `Error: message` when no span
+  - File mode shows correct multi-line positions
 - [ ] Stack traces showing call chain
 - [ ] Error recovery suggestions
 

--- a/src/eval.seq
+++ b/src/eval.seq
@@ -94,6 +94,26 @@ union EvalResult {
 : eval-define-value ( EvalResult -- Sexpr )
   1 variant.field-at ;
 
+# Format an EvalErr with span information for display
+# Returns: "Error [line:col]: message" or "Error: message" if no span
+: format-eval-error ( EvalResult -- String )
+  dup eval-err-span
+  dup no-span? if
+    # No span - just use message
+    drop "Error: " swap eval-err-message string.concat
+  else
+    # Has span - format with location
+    # Stack: EvalResult Span
+    dup span-start-line int->string   # EvalResult Span LineStr
+    ":" string.concat                  # EvalResult Span "Line:"
+    swap span-start-col int->string   # EvalResult "Line:" ColStr
+    string.concat                      # EvalResult "Line:Col"
+    "Error [" swap string.concat      # EvalResult "Error [Line:Col"
+    "]: " string.concat               # EvalResult "Error [Line:Col]: "
+    swap eval-err-message string.concat  # Full error message
+  then
+;
+
 
 # ============================================
 # Arity Checking Helpers
@@ -4760,7 +4780,7 @@ union EvalResult {
 : eval-print ( String -- )
   parse env-empty eval-with-env
   dup eval-err? if
-    "Error: " swap eval-err-message string.concat io.write-line
+    format-eval-error io.write-line
   else
     eval-ok-value sexpr-to-string io.write-line
   then ;

--- a/src/repl.seq
+++ b/src/repl.seq
@@ -58,7 +58,7 @@ include ffi:libedit
         else
             dup eval-err? if
                 # Print error but continue
-                "Error: " swap eval-err-message string.concat io.write-line
+                format-eval-error io.write-line
                 scdr swap
                 eval-all-quiet
             else
@@ -85,7 +85,7 @@ include ffi:libedit
         else
             dup eval-err? if
                 # Print error and continue
-                "Error: " swap eval-err-message string.concat io.write-line
+                format-eval-error io.write-line
                 scdr swap
                 eval-all-print
             else
@@ -263,14 +263,15 @@ include ffi:libedit
 # Stdin Mode - Read all lines, then evaluate (for piped input)
 # ============================================
 
-# Read all lines until EOF (preserves newlines for comments)
+# Read all lines until EOF (preserves newlines for comments and line tracking)
 : read-all-stdin ( String -- String )
     io.read-line+
     0 i.= if
         # EOF reached
         drop
     else
-        # Got a line - append to accumulator (keep newline for comments)
+        # Got a line - append newline since io.read-line+ strips it
+        "\n" string.concat
         string.concat
         read-all-stdin
     then


### PR DESCRIPTION
⏺ Done! Here's a summary:

  Completed: Error Messages with Line/Column Info

  Changes:

  1. src/eval.seq: Added format-eval-error function (lines 97-115)
    - Formats errors as Error [line:col]: message when span is available
    - Falls back to Error: message when no span
  2. src/repl.seq: Updated all error outputs to use format-eval-error
    - Lines 61, 88: eval-all-quiet and eval-all-print
    - Also fixed read-all-stdin to preserve newlines (line 274)
  3. src/eval.seq: Updated eval-print to use format-eval-error (line 4783)

  Results:
  - File mode: Error [4:6]: undefined symbol: undefined-var ✓
  - Undefined symbols show location: Error [8:2]: undefined symbol: lamda ✓
  - Suggestions work with location: Did you mean 'lambda'? ✓
  - Arity errors don't have span info yet (future enhancement)

  Note on REPL/piped input:
  - In interactive mode, each expression is tokenized separately, so line numbers reset per expression. This is expected behavior for REPL.
  - File mode shows correct absolute line numbers.