### PR TITLE
⏺ Here's a summary of what was accomplished:

### DIFF
--- a/justfile
+++ b/justfile
@@ -95,6 +95,7 @@ lisp-test: build
         tests/lisp/edge_cases/parser.slisp \
         tests/lisp/edge_cases/io.slisp \
         tests/lisp/edge_cases/suggestions.slisp \
+        tests/lisp/edge_cases/stack_trace.slisp \
         tests/lisp/all.slisp \
         > "$tmp"
     ./target/seqlisp "$tmp"

--- a/src/eval.seq
+++ b/src/eval.seq
@@ -140,32 +140,24 @@ union EvalResult {
 
 # Add a stack frame to an existing EvalErr
 # Used when errors propagate through function calls
+# If input is not an EvalErr, returns it unchanged
 : add-stack-frame ( EvalResult String SourceSpan -- EvalResult )
   # Stack: EvalResult FuncName FuncSpan
-  rot  # FuncName FuncSpan EvalResult
-  dup eval-err? if
-    # Extract components from error
-    dup eval-err-message  # FuncName FuncSpan EvalResult Message
-    over eval-err-span    # FuncName FuncSpan EvalResult Message Span
-    rot eval-err-stack    # FuncName FuncSpan Message Span Stack
-    # Stack positions: 0=Stack, 1=Span, 2=Message, 3=FuncSpan, 4=FuncName
-    # We want to call stack-push(FuncName, FuncSpan, Stack)
-    # Rearrange stack for stack-push: need String SourceSpan CallStack on top
-    4 pick  # ... Stack FuncName (pos 4 -> FuncName)
-    # Now: 0=FuncName, 1=Stack, 2=Span, 3=Message, 4=FuncSpan, 5=FuncName
-    4 pick  # ... Stack FuncName FuncSpan (pos 4 -> FuncSpan)
-    # Now: 0=FuncSpan, 1=FuncName, 2=Stack, 3=Span, 4=Message, 5=FuncSpan, 6=FuncName
-    2 pick  # ... Stack FuncName FuncSpan Stack (pos 2 -> Stack)
-    # Now top 3: FuncName FuncSpan Stack (Stack on top) - correct for stack-push!
-    stack-push  # ... Message Span Stack NewStack (consumes FuncName FuncSpan Stack)
-    # Drop the old Stack that's still on the stack (at position 1)
-    nip  # FuncName FuncSpan Message Span NewStack
-    # Reconstruct with new stack
-    eval-err-with-stack  # FuncName FuncSpan NewEvalResult
-    nip nip  # NewEvalResult
+  2 pick eval-err? if
+    # It's an error - extract, add frame, reconstruct
+    # First, build the new stack by pushing frame onto existing stack
+    2 pick eval-err-stack   # EvalResult FuncName FuncSpan OldStack
+    stack-push              # EvalResult NewStack
+    # Now extract message and span from original error
+    over eval-err-message   # EvalResult NewStack Message
+    2 pick eval-err-span    # EvalResult NewStack Message Span
+    # Rearrange for eval-err-with-stack: need Message Span NewStack
+    rot                     # EvalResult Message Span NewStack
+    eval-err-with-stack     # EvalResult NewEvalResult
+    nip                     # NewEvalResult
   else
-    # Not an error, just drop FuncName and FuncSpan
-    nip nip
+    # Not an error - drop FuncName and FuncSpan, return original
+    drop drop
   then
 ;
 
@@ -215,8 +207,12 @@ union EvalResult {
 
 # Format an EvalErr with span and stack trace for display
 # Returns multi-line string with error and stack trace
-# IMPORTANT: Only call this on EvalErr results!
+# If called on non-EvalErr, returns a generic message
 : format-eval-error ( EvalResult -- String )
+  # Guard: only process EvalErr variants
+  dup eval-err? not if
+    drop "Error: unexpected result type"
+  else
   # First format the error line
   dup eval-err-span
   dup no-span? if
@@ -242,6 +238,7 @@ union EvalResult {
     "" format-call-stack               # Format stack frames
     string.concat                      # Combine
   then
+  then  # Close guard if-else
 ;
 
 

--- a/tests/lisp/all.slisp
+++ b/tests/lisp/all.slisp
@@ -36,7 +36,8 @@
   (append gensym-tests
   (append parser-edge-tests
   (append io-tests
-          suggestion-tests))))))))))))))))))))))
+  (append suggestion-tests
+          stack-trace-tests))))))))))))))))))))))))
 
 ;; ============================================
 ;; Run Tests and Report

--- a/tests/lisp/edge_cases/stack_trace.slisp
+++ b/tests/lisp/edge_cases/stack_trace.slisp
@@ -1,0 +1,61 @@
+;; Stack Trace Infrastructure Tests
+;; Tests for the CallFrame, CallStack types and error formatting
+
+;; Test that errors still work correctly with empty stacks
+;; (The infrastructure is in place but not actively adding frames)
+
+;; Basic error should format correctly
+(define stack-trace-tests (list
+  ;; Division by zero error
+  (test 'div-error-format
+    (assert-error (/ 1 0)))
+
+  ;; Undefined symbol error
+  (test 'undefined-sym-error
+    (assert-error undefined-symbol-xyz))
+
+  ;; Arity error (cons requires exactly 2 args)
+  (test 'arity-error
+    (assert-error (cons 1)))
+
+  ;; Type error in car
+  (test 'type-error-car
+    (assert-error (car 42)))
+
+  ;; Type error in cdr
+  (test 'type-error-cdr
+    (assert-error (cdr 42)))
+
+  ;; Nested function error (error propagates through call chain)
+  (test 'nested-error
+    (let inner (lambda (x) (/ x 0))
+      (let outer (lambda (x) (inner x))
+        (assert-error (outer 5)))))
+
+  ;; Deep nested error
+  (test 'deep-nested-error
+    (let f1 (lambda (x) (/ x 0))
+      (let f2 (lambda (x) (f1 x))
+        (let f3 (lambda (x) (f2 x))
+          (assert-error (f3 5))))))
+
+  ;; Error in conditional branch
+  (test 'error-in-if
+    (assert-error (if #t (/ 1 0) 42)))
+
+  ;; Error in let binding
+  (test 'error-in-let-binding
+    (assert-error (let x (/ 1 0) x)))
+
+  ;; Error with try - verify try catches errors
+  (test 'try-catches-error
+    (assert-eq (car (try (/ 1 0))) 'error))
+
+  ;; Try returns ok on success
+  (test 'try-ok-on-success
+    (assert-eq (car (try (+ 1 2))) 'ok))
+
+  ;; Try captures error message
+  (test 'try-error-message
+    (assert-true (list? (try (/ 1 0)))))
+))


### PR DESCRIPTION
  Stack Trace Implementation - Summary

  Completed Infrastructure

  1. CallFrame and CallStack types - Added union types for tracking call chains
  2. Extended EvalErr - Added stack: CallStack field to error type
  3. Helper functions - stack-push, stack-empty, add-stack-frame, format-call-stack, format-stack-frame
  4. Stack trace formatting - format-eval-error displays stack traces when present

  TCO Compatibility Issue

  During testing, I discovered that keeping function name/span on the Seq stack during apply-closure breaks Tail Call Optimization. With the original implementation:
  - Deep recursion (10000+ calls) caused stack overflow
  - TCO tests failed

  The fix was to remove the stack frame tracking from dispatch-user-defined to preserve TCO:
  - All 433 tests now pass
  - TCO works correctly for deep recursion

  Current State

  - Stack trace infrastructure is in place but not currently active
  - Errors show the error message but not the call chain
  - TCO works correctly

  Next Steps (for future work)

  To enable stack traces without breaking TCO, possible approaches include:
  1. Thread-local or global call stack - Track calls separately from Seq stack
  2. Lazy stack capture - Only capture stack info when an error actually occurs
  3. Compile-time transformation - Annotate tail calls differently than regular calls