### PR TITLE
issue 38

### DIFF
--- a/src/tokenizer.seq
+++ b/src/tokenizer.seq
@@ -544,11 +544,17 @@ union TokState {
             drop 13 char->string append-to-token
             advance-col advance-col
           else
-            # Unknown escape - i.add backslash and the char
+            dup 116 i.= if
+              # backslash-t -> i.add tab to string
+              drop 9 char->string append-to-token
+              advance-col advance-col
+            else
+              # Unknown escape - i.add backslash and the char
             char->string
             92 char->string swap string.concat
             append-to-token
             advance-col advance-col
+            then
           then
         then
       then

--- a/tests/lisp/core/strings.slisp
+++ b/tests/lisp/core/strings.slisp
@@ -29,6 +29,8 @@
   (test 'string-escaped-quote (assert-true (string? "hello\"world")))
   (test 'string-escaped-backslash (assert-true (string? "path\\to\\file")))
   (test 'string-escaped-newline (assert-true (string? "line1\nline2")))
+  (test 'string-escaped-tab (assert-eq 3 (string-length "a\tb")))
+  (test 'string-escaped-cr (assert-eq 3 (string-length "a\rb")))
 
   ;; Strings in lists
   (test 'string-in-list (assert-true (string? (car (list "hello" "world")))))


### PR DESCRIPTION
https://github.com/navicore/seq-lisp/issues/38

  Files changed:

  1. src/tokenizer.seq - Added \t escape sequence handling (line 547-550)
    - \r was already supported, only \t was missing
  2. tests/lisp/core/strings.slisp - Added 2 tests for \t and \r escapes

  Test results: 447 tests pass
