### PR TITLE
⏺ The lockup is a Claude Code issue, not seqlisp. The command works f…

### DIFF
--- a/src/eval.seq
+++ b/src/eval.seq
@@ -1843,12 +1843,20 @@ union EvalResult {
 
 : eval-write-with-env ( SexprList Env -- EvalResult )
   # (write expr) - like display but without trailing newline
-  swap scdr scar
-  swap eval-with-env
+  over 1 "write" check-arity
   dup eval-err? if
-    # Error - return it
+    # Stack: SexprList Env SexprList EvalResult -> EvalResult
+    nip nip nip
   else
-    dup eval-ok-value sexpr-to-display-string io.write
+    # Stack: SexprList Env SexprList EvalResult -> SexprList Env
+    drop drop
+    swap scdr scar
+    swap eval-with-env
+    dup eval-err? if
+      # Error - return it
+    else
+      dup eval-ok-value sexpr-to-display-string io.write
+    then
   then
 ;
 

--- a/tests/lisp/edge_cases/io.slisp
+++ b/tests/lisp/edge_cases/io.slisp
@@ -18,6 +18,10 @@
   ;; write outputs strings without quotes, without newline (for LSP protocol)
   ;; (test 'write-returns-value (assert-eq (write "hello") "hello"))
 
+  ;; Arity checks for write
+  (test 'write-arity-zero (assert-error (write)))
+  (test 'write-arity-two (assert-error (write "a" "b")))
+
   ;; Placeholder - we need at least one test
   (test 'io-placeholder (assert-true #t))))
 


### PR DESCRIPTION
…ine in your terminal.
https://github.com/navicore/seq-lisp/issues/39
  The write implementation is correct and complete for issue #39:
  - (write "hello") outputs hello (no newline) ✓
  - Returns the value it printed ✓
  - All 447 tests pass ✓

  Files changed for #39:
  - src/eval.seq - Added write function using io.write
  - tests/lisp/edge_cases/io.slisp - Documented the new function