### PR TITLE
⏺ The Seq 4.0 migration is complete. Here's a summary of the changes …

### DIFF
--- a/src/eval.seq
+++ b/src/eval.seq
@@ -42,21 +42,21 @@ union CallStack {
 
 # CallFrame accessors
 : frame-name ( CallFrame -- String )
-  0 variant.field-at ;
+  Frame-name ;
 
 : frame-span ( CallFrame -- SourceSpan )
-  1 variant.field-at ;
+  Frame-span ;
 
 # CallStack predicates
 : stack-empty? ( CallStack -- Bool )
-  variant.tag :StackEmpty symbol.= ;
+  is-StackEmpty? ;
 
 # CallStack accessors
 : stack-top ( CallStack -- CallFrame )
-  0 variant.field-at ;
+  StackFrame-frame ;
 
 : stack-rest ( CallStack -- CallStack )
-  1 variant.field-at ;
+  StackFrame-rest ;
 
 # ============================================
 # EvalResult Union Type
@@ -92,26 +92,26 @@ union EvalResult {
 
 # Predicates
 : eval-ok? ( EvalResult -- Bool )
-  variant.tag :EvalOk symbol.= ;
+  is-EvalOk? ;
 
 : eval-err? ( EvalResult -- Bool )
-  variant.tag :EvalErr symbol.= ;
+  is-EvalErr? ;
 
 : eval-define? ( EvalResult -- Bool )
-  variant.tag :EvalDefine symbol.= ;
+  is-EvalDefine? ;
 
 # Accessors
 : eval-ok-value ( EvalResult -- Sexpr )
-  0 variant.field-at ;
+  EvalOk-value ;
 
 : eval-err-message ( EvalResult -- String )
-  0 variant.field-at ;
+  EvalErr-message ;
 
 : eval-err-span ( EvalResult -- SourceSpan )
-  1 variant.field-at ;
+  EvalErr-span ;
 
 : eval-err-stack ( EvalResult -- CallStack )
-  2 variant.field-at ;
+  EvalErr-stack ;
 
 # Create error at the location of a Sexpr
 : eval-err-from ( String Sexpr -- EvalResult )
@@ -162,10 +162,10 @@ union EvalResult {
 ;
 
 : eval-define-name ( EvalResult -- String )
-  0 variant.field-at ;
+  EvalDefine-name ;
 
 : eval-define-value ( EvalResult -- Sexpr )
-  1 variant.field-at ;
+  EvalDefine-def_value ;
 
 # Format a span as "line:col"
 : format-span ( SourceSpan -- String )
@@ -501,12 +501,12 @@ union EvalResult {
 # Stack: target env -> best_name best_dist
 : find-best-in-env ( String Env -- String Int )
   # Stack: target env
-  dup variant.tag :EnvEmpty symbol.= if
+  dup is-EnvEmpty? if
     # EnvEmpty - no match found in env
     drop drop "" 999
   else
     # EnvExtend - check this binding and recurse
-    dup 0 variant.field-at   # target env binding
+    dup EnvExtend-binding    # target env binding
     binding-name             # target env binding_name
     2 pick over              # target env binding_name target binding_name
     simple-similarity        # target env binding_name dist
@@ -514,7 +514,7 @@ union EvalResult {
     # Recurse to check rest of environment
     # Stack: target env binding_name dist
     3 pick                   # target env binding_name dist target
-    3 pick 1 variant.field-at  # target env binding_name dist target parent
+    3 pick EnvExtend-parent  # target env binding_name dist target parent
     find-best-in-env         # target env binding_name dist rest_name rest_dist
 
     # Compare: keep the better one
@@ -623,12 +623,12 @@ union EvalResult {
 : env-lookup-raw ( String Env -- EvalResult )
   # Stack: Name Env
   # Returns EvalOk with the value, or EvalErr if not found
-  dup variant.tag :EnvEmpty symbol.= if
+  dup is-EnvEmpty? if
     # EnvEmpty - not found, return error
     drop "undefined symbol: " swap string.concat eval-err
   else
     # EnvExtend - extract binding and parent
-    dup 0 variant.field-at  # Name Env Binding
+    dup EnvExtend-binding   # Name Env Binding
     dup binding-name        # Name Env Binding BindingName
     3 pick string.equal? if
       # Found it
@@ -638,7 +638,7 @@ union EvalResult {
     else
       # Keep looking
       drop                  # Name Env
-      1 variant.field-at    # Name Parent
+      EnvExtend-parent      # Name Parent
       env-lookup-raw
     then
   then ;
@@ -647,13 +647,13 @@ union EvalResult {
 : env-concat ( Env Env -- Env )
   # Stack: Env1 Env2 -> Result where Env1 bindings come first
   swap  # Env2 Env1
-  dup variant.tag :EnvEmpty symbol.= if
+  dup is-EnvEmpty? if
     # EnvEmpty - just return Env2
     drop
   else
     # EnvExtend - extract binding and parent
-    dup 0 variant.field-at  # Env2 Env1 Binding
-    swap 1 variant.field-at # Env2 Binding Parent
+    dup EnvExtend-binding   # Env2 Env1 Binding
+    swap EnvExtend-parent   # Env2 Binding Parent
     rot                     # Binding Parent Env2
     env-concat              # Binding ConcatResult
     Make-EnvExtend          # Result
@@ -677,14 +677,13 @@ union EvalResult {
 # Returns: EvalResult (EvalOk, EvalErr, or EvalDefine)
 : eval-with-env ( Sexpr Env -- EvalResult )
   # Stack: Expr Env
-  over variant.tag
-  dup :SNum symbol.= if
+  over snum? if
     # SNum - return as-is wrapped in EvalOk
-    drop drop eval-ok
+    drop eval-ok
   else
-    dup :SSym symbol.= if
+    over ssym? if
       # SSym - check for self-evaluating symbols (#t, #f) or lookup
-      drop swap dup ssym-val
+      swap dup ssym-val
       dup "#t" string.equal? over "#f" string.equal? or if
         # Boolean literal - return as-is
         drop nip eval-ok
@@ -698,7 +697,7 @@ union EvalResult {
         swap eval-result-add-span  # Add span to any error
       then
     else
-      :SList symbol.= if
+      over slist? if
         # SList - function application
         eval-list-with-env
       else
@@ -2442,11 +2441,11 @@ union EvalResult {
             dup eval-define-name    # Exprs Env LastValue EvalDef Name
             swap eval-define-value  # Exprs Env LastValue Name Value
             3 pick env-extend       # Exprs Env LastValue Name Value Env -> Exprs Env LastValue NewEnv
-            # Now need: RestExprs NewEnv snil
+            # Now need: RestExprs NewEnv empty-sexpr
             # Stack: Exprs Env LastValue NewEnv
             nip nip                 # Exprs NewEnv (drop LastValue and old Env)
             swap scdr               # NewEnv RestExprs
-            swap snil               # RestExprs NewEnv snil
+            swap snil slist         # RestExprs NewEnv (empty-list Sexpr)
             eval-all-with-errors-loop
         then then
     then
@@ -2470,10 +2469,10 @@ union EvalResult {
         tokenize parse-all-for-lsp  # Parse all expressions -> SexprList
         dup snil? if
           # Empty - return (ok ())
-          drop snil make-ok-result eval-ok
+          drop snil slist make-ok-result eval-ok
         else
           # Evaluate all with empty initial env
-          env-empty snil eval-all-with-errors-loop
+          env-empty snil slist eval-all-with-errors-loop
         then
       else
         drop "eval-all-with-errors: argument must be a string" eval-err
@@ -3456,7 +3455,7 @@ union EvalResult {
       dup sclosure? if
         sclosure-val  # -> Env Args Closure (unwrap from Sexpr)
         swap scdr  # -> Env Closure RestArgs
-        dup scar 2 pick eval-with-env  # Eval init -> Env Closure RestArgs EvalResult
+        dup scar 3 pick eval-with-env  # Eval init -> Env Closure RestArgs EvalResult
         dup eval-err? if
           nip nip nip  # Error - propagate (Env Closure RestArgs EvalResult -> 4 items)
         else
@@ -4356,10 +4355,9 @@ union EvalResult {
     dup eval-err? if
       # Error - clean up and return
       # Stack: AccEnv Params Args EvalEnv EvalResult (4,3,2,1,0)
-      swap drop    # -> AccEnv Params Args EvalResult
-      swap drop    # -> AccEnv Params EvalResult
-      swap drop    # -> AccEnv EvalResult
-      swap snil swap  # -> AccEnv () EvalResult
+      # Need to produce: Env SexprList EvalResult
+      nip nip nip   # -> AccEnv EvalResult (drop EvalEnv, Args, Params)
+      snil swap     # -> AccEnv snil EvalResult (insert empty param list)
     else
       eval-ok-value  # -> AccEnv Params Args EvalEnv ArgVal
       # Rearrange to get AccEnv to top for env-extend
@@ -4473,8 +4471,8 @@ union EvalResult {
     # Get rest param name (param after the dot)
     2 pick scdr scar ssym-val  # -> ... EvalEnv RestParamName
     # Evaluate all remaining args and collect as list
-    2 pick                     # -> ... RestParamName Args
-    3 pick                     # -> ... RestParamName Args EvalEnv
+    2 pick                     # -> ... RestParamName Args (pos 0=Args)
+    2 pick                     # -> ... RestParamName Args EvalEnv (EvalEnv was at pos 2)
     eval-collect-rest          # -> ... RestParamName EvalResult
     dup eval-err? if
       # Error during evaluation

--- a/src/json.seq
+++ b/src/json.seq
@@ -29,10 +29,10 @@ union JsonResult {
   Make-JState ;
 
 : jstate-input ( JsonState -- String )
-  0 variant.field-at ;
+  JState-input ;
 
 : jstate-pos ( JsonState -- Int )
-  1 variant.field-at ;
+  JState-pos ;
 
 # Result constructors and accessors
 : json-ok ( Sexpr JsonState -- JsonResult )
@@ -42,19 +42,19 @@ union JsonResult {
   Make-JErr ;
 
 : json-ok? ( JsonResult -- Bool )
-  variant.tag :JOk symbol.= ;
+  is-JOk? ;
 
 : json-err? ( JsonResult -- Bool )
-  variant.tag :JErr symbol.= ;
+  is-JErr? ;
 
 : json-ok-value ( JsonResult -- Sexpr )
-  0 variant.field-at ;
+  JOk-value ;
 
 : json-ok-state ( JsonResult -- JsonState )
-  1 variant.field-at ;
+  JOk-state ;
 
 : json-err-msg ( JsonResult -- String )
-  0 variant.field-at ;
+  JErr-message ;
 
 # ============================================
 # Helper Functions

--- a/src/parser.seq
+++ b/src/parser.seq
@@ -22,10 +22,10 @@ union ParseResult {
   Make-PResult ;
 
 : result-expr ( ParseResult -- Sexpr )
-  0 variant.field-at ;
+  PResult-expr ;
 
 : result-tokens ( ParseResult -- TokenList )
-  1 variant.field-at ;
+  PResult-remaining ;
 
 # ============================================
 # Span Helpers
@@ -326,7 +326,10 @@ union ParseResult {
 ;
 
 : parse-list-items ( SexprList TokenList -- ParseResult )
-  no-span rot rot parse-list-items-with-span ;
+  # Stack: SexprList TokenList
+  # Need: SexprList SourceSpan TokenList for parse-list-items-with-span
+  no-span swap     # SexprList SourceSpan TokenList
+  parse-list-items-with-span ;
 
 : parse-list-items-with-span ( SexprList SourceSpan TokenList -- ParseResult )
   # Stack: Acc LparenSpan Tokens (Tokens on top)

--- a/src/repl.seq
+++ b/src/repl.seq
@@ -215,7 +215,7 @@ include "vim-line"
     dup 0 i.< if
         # Negative balance - too many closing parens
         drop "Error: unexpected ')'" io.write-line
-        drop "" swap repl-loop
+        swap drop "" swap repl-loop
     else
         0 i.=
         # Stack: History NewAcc Env BalancedBool

--- a/src/sexpr.seq
+++ b/src/sexpr.seq
@@ -146,83 +146,85 @@ union SexprList {
 # ============================================
 
 : snum? ( Sexpr -- Bool )
-  variant.tag :SNum symbol.= ;
+  is-SNum? ;
 
 : ssym? ( Sexpr -- Bool )
-  variant.tag :SSym symbol.= ;
+  is-SSym? ;
 
 : slist? ( Sexpr -- Bool )
-  variant.tag :SList symbol.= ;
+  is-SList? ;
 
 : sclosure? ( Sexpr -- Bool )
-  variant.tag :SClosure symbol.= ;
+  is-SClosure? ;
 
 : smacro? ( Sexpr -- Bool )
-  variant.tag :SMacro symbol.= ;
+  is-SMacro? ;
 
 : sstring? ( Sexpr -- Bool )
-  variant.tag :SString symbol.= ;
+  is-SString? ;
 
 : sfloat? ( Sexpr -- Bool )
-  variant.tag :SFloat symbol.= ;
+  is-SFloat? ;
 
 : snil? ( SexprList -- Bool )
-  variant.tag :SNil symbol.= ;
+  is-SNil? ;
 
 # Closure type predicates
 : named-closure? ( LispClosure -- Bool )
-  variant.tag :NamedClos symbol.= ;
+  is-NamedClos? ;
 
 # SourceSpan predicates
 : span? ( SourceSpan -- Bool )
-  variant.tag :Span symbol.= ;
+  is-Span? ;
 
 : no-span? ( SourceSpan -- Bool )
-  variant.tag :NoSpan symbol.= ;
+  is-NoSpan? ;
 
 # ============================================
 # Accessors
 # ============================================
 
 : snum-val ( Sexpr -- Int )
-  0 variant.field-at ;
+  SNum-value ;
 
 : ssym-val ( Sexpr -- String )
-  0 variant.field-at ;
+  SSym-name ;
 
 : slist-val ( Sexpr -- SexprList )
-  0 variant.field-at ;
+  SList-items ;
 
 : sclosure-val ( Sexpr -- LispClosure )
-  0 variant.field-at ;
+  SClosure-closure ;
 
 : smacro-val ( Sexpr -- LispClosure )
-  0 variant.field-at ;
+  SMacro-macro ;
 
 : sstring-val ( Sexpr -- String )
-  0 variant.field-at ;
+  SString-value ;
 
 : sfloat-val ( Sexpr -- Float )
-  0 variant.field-at ;
+  SFloat-value ;
 
 # Get the span from any Sexpr (span is always field 1)
+# Note: using variant.field-at for polymorphic access across all Sexpr variants
 : sexpr-span ( Sexpr -- SourceSpan )
   1 variant.field-at ;
 
 : scar ( SexprList -- Sexpr )
-  0 variant.field-at ;
+  SCons-head ;
 
 : scdr ( SexprList -- SexprList )
-  1 variant.field-at ;
+  SCons-tail ;
 
 # Binding accessors
 : binding-name ( Binding -- String )
-  0 variant.field-at ;
+  Bind-name ;
 
 : binding-value ( Binding -- Sexpr )
-  1 variant.field-at ;
+  Bind-value ;
 
 # Closure accessors (work for both Clos and NamedClos)
+# Note: using variant.field-at for polymorphic access across Clos and NamedClos
 : closure-params ( LispClosure -- Sexpr )
   0 variant.field-at ;
 
@@ -231,23 +233,23 @@ union SexprList {
 
 # Only valid for NamedClos - use named-closure? to check first
 : closure-self-name ( LispClosure -- String )
-  3 variant.field-at ;
+  NamedClos-self_name ;
 
 : closure-env ( LispClosure -- Env )
   2 variant.field-at ;
 
 # SourceSpan accessors (only valid when span? is true)
 : span-start-line ( SourceSpan -- Int )
-  0 variant.field-at ;
+  Span-start_line ;
 
 : span-start-col ( SourceSpan -- Int )
-  1 variant.field-at ;
+  Span-start_col ;
 
 : span-end-line ( SourceSpan -- Int )
-  2 variant.field-at ;
+  Span-end_line ;
 
 : span-end-col ( SourceSpan -- Int )
-  3 variant.field-at ;
+  Span-end_col ;
 
 # ============================================
 # Pretty Printing

--- a/src/tokenizer.seq
+++ b/src/tokenizer.seq
@@ -42,10 +42,10 @@ union TokState {
   Make-Tok ;
 
 : tok-text ( Token -- String )
-  0 variant.field-at ;
+  Tok-text ;
 
 : tok-span ( Token -- SourceSpan )
-  1 variant.field-at ;
+  Tok-span ;
 
 # ============================================
 # Token List Constructors and Accessors
@@ -63,13 +63,13 @@ union TokState {
   rot rot make-token swap tcons-tok ;
 
 : tnil? ( TokenList -- Bool )
-  variant.tag :TNil symbol.= ;
+  is-TNil? ;
 
 : tcar ( TokenList -- Token )
-  0 variant.field-at ;
+  TCons-token ;
 
 : tcdr ( TokenList -- TokenList )
-  1 variant.field-at ;
+  TCons-rest ;
 
 # Reverse token list (preserving spans)
 : trev ( TokenList -- TokenList )
@@ -93,13 +93,13 @@ union TokState {
   Make-Pos ;
 
 : pos-pos ( TokPos -- Int )
-  0 variant.field-at ;
+  Pos-pos ;
 
 : pos-line ( TokPos -- Int )
-  1 variant.field-at ;
+  Pos-line ;
 
 : pos-col ( TokPos -- Int )
-  2 variant.field-at ;
+  Pos-col ;
 
 # ============================================
 # TokAccum Constructors and Accessors
@@ -113,13 +113,13 @@ union TokState {
   "" rot rot make-accum ;
 
 : accum-text ( TokAccum -- String )
-  0 variant.field-at ;
+  Accum-text ;
 
 : accum-start-line ( TokAccum -- Int )
-  1 variant.field-at ;
+  Accum-start_line ;
 
 : accum-start-col ( TokAccum -- Int )
-  2 variant.field-at ;
+  Accum-start_col ;
 
 # ============================================
 # TokState Constructors and Accessors
@@ -129,16 +129,16 @@ union TokState {
   Make-TState ;
 
 : state-input ( TokState -- String )
-  0 variant.field-at ;
+  TState-input ;
 
 : state-current ( TokState -- TokPos )
-  1 variant.field-at ;
+  TState-current ;
 
 : state-accum ( TokState -- TokAccum )
-  2 variant.field-at ;
+  TState-accum ;
 
 : state-tokens ( TokState -- TokenList )
-  3 variant.field-at ;
+  TState-tokens ;
 
 # Convenience accessors that unwrap nested types
 : state-pos ( TokState -- Int )

--- a/src/vim-line.seq
+++ b/src/vim-line.seq
@@ -36,10 +36,10 @@ union EditorState {
 : ed-make ( String Int Int String -- EditorState ) Make-EdState ;
 
 # Accessors
-: ed-buffer ( EditorState -- String ) 0 variant.field-at ;
-: ed-cursor ( EditorState -- Int ) 1 variant.field-at ;
-: ed-mode ( EditorState -- Int ) 2 variant.field-at ;
-: ed-yank ( EditorState -- String ) 3 variant.field-at ;
+: ed-buffer ( EditorState -- String ) EdState-buffer ;
+: ed-cursor ( EditorState -- Int ) EdState-cursor ;
+: ed-mode ( EditorState -- Int ) EdState-mode ;
+: ed-yank ( EditorState -- String ) EdState-yank_reg ;
 
 # Updaters - return new EditorState with one field changed
 : ed-with-buffer ( EditorState String -- EditorState )
@@ -125,7 +125,7 @@ union UndoList {
 
 # Check if undo stack is empty
 : undo-empty? ( UndoStack -- Bool )
-    variant.tag :UndoNil symbol.= ;
+    is-UndoNil? ;
 
 # Pop from undo stack - returns UndoStack Buffer Cursor
 # If stack is empty, returns empty string and 0
@@ -133,10 +133,10 @@ union UndoList {
     dup undo-empty? if
         "" 0  # Empty stack returns empty state
     else
-        # UndoCons has fields: buffer(0), cursor(1), tail(2)
-        dup 2 variant.field-at  # Stack Tail
-        swap dup 0 variant.field-at  # Tail Stack Buffer
-        swap 1 variant.field-at  # Tail Buffer Cursor
+        # UndoCons has fields: buffer, cursor, tail
+        dup UndoCons-tail    # Stack Tail
+        swap dup UndoCons-buffer  # Tail Stack Buffer
+        swap UndoCons-cursor # Tail Buffer Cursor
     then ;
 
 # Limit undo stack depth (called after push)
@@ -156,15 +156,15 @@ union UndoList {
             # Recursive case: keep this entry, limit tail
             # Stack: UndoStack(1) Remaining(0)
             # Get tail and recurse first
-            over 2 variant.field-at  # Stack Remaining Tail
+            over UndoCons-tail       # Stack Remaining Tail
             over 1 i.subtract        # Stack Remaining Tail Remaining-1
             undo-limit-loop          # Stack Remaining LimitedTail
             # Now build new node: need Buffer Cursor LimitedTail for Make-UndoCons
-            2 pick 0 variant.field-at  # Stack Remaining LimitedTail Buffer
-            3 pick 1 variant.field-at  # Stack Remaining LimitedTail Buffer Cursor
-            rot                        # Stack Remaining Buffer Cursor LimitedTail
-            Make-UndoCons              # Stack Remaining NewUndoStack
-            nip nip                    # NewUndoStack (drop Remaining and old UndoStack)
+            2 pick UndoCons-buffer   # Stack Remaining LimitedTail Buffer
+            3 pick UndoCons-cursor   # Stack Remaining LimitedTail Buffer Cursor
+            rot                      # Stack Remaining Buffer Cursor LimitedTail
+            Make-UndoCons            # Stack Remaining NewUndoStack
+            nip nip                  # NewUndoStack (drop Remaining and old UndoStack)
         then
     then ;
 


### PR DESCRIPTION
…made:

  Summary

  Successfully migrated seq-lisp from Seq 3.x to 4.0, which introduces compile-time safety for union types via auto-generated predicates and accessors.

  Changes Made

  1. src/sexpr.seq - Updated 22 predicates and accessors:
  - Predicates now use is-VariantName? (e.g., snum? → is-SNum?)
  - Accessors now use VariantName-fieldname (e.g., snum-val → SNum-value)
  - Kept variant.field-at for polymorphic accessors (sexpr-span, closure-params, closure-body, closure-env)

  2. src/tokenizer.seq - Updated 14 accessors/predicates:
  - tnil? → is-TNil?
  - Token, Pos, Accum, State accessors updated

  3. src/parser.seq - Updated 2 accessors:
  - result-expr → PResult-expr
  - result-tokens → PResult-remaining

  4. src/json.seq - Updated 7 predicates/accessors:
  - json-ok?/json-err? → is-JOk?/is-JErr?
  - State and result accessors updated

  5. src/eval.seq - Updated predicates/accessors and fixed pre-existing bugs:
  - stack-empty?, eval-ok?, etc. → is-StackEmpty?, is-EvalOk?
  - Frame, stack, and result accessors updated
  - Environment operations (find-best-in-env, env-lookup-raw, env-concat) updated

  6. src/vim-line.seq - Updated 5 accessors/predicates:
  - undo-empty? → is-UndoNil?
  - EditorState and UndoList accessors updated

  Bug Fixes Uncovered by Seq 4.0's Stricter Type Checking

  The migration revealed several pre-existing bugs that Seq 4.0's improved type system caught:

  1. src/repl.seq:218 - Stack order bug in error handling path
  2. src/eval.seq:2448 - snil passed where Sexpr expected (now snil slist)
  3. src/eval.seq:2472,2475 - Same snil/Sexpr type confusion
  4. src/eval.seq:3458 - Wrong pick index (2 instead of 3) for getting Env
  5. src/eval.seq:4358 - Stack cleanup produced wrong order
  6. src/eval.seq:4475 - Wrong pick index for EvalEnv
  7. src/parser.seq:329 - Wrong stack rearrangement for parse-list-items

  Test Results

  - All 8 Seq unit tests pass
  - All 449 Lisp tests pass
  - All 6 LSP integration tests pass