### PR TITLE
  - History data: stores multiline expressions with real \n — correct…

### DIFF
--- a/docs/design/history-data-vs-presentation.md
+++ b/docs/design/history-data-vs-presentation.md
@@ -1,0 +1,72 @@
+# Design: Separate History Data from Presentation
+
+## Problem
+
+History currently muddles program data with display artifacts:
+
+- **In-session recall**: buffer contains raw `\n` characters from the accumulated expression. The renderer tries to display these with `... ` continuation prompts, but cursor math breaks.
+- **Disk persistence**: `history-to-string` joins entries with `\n`, and `history-load-lines` splits on `\n`. A multiline entry like `(define fact (lambda (n)\n  (if ...)))` gets split into separate lines on save/load. So in-session history and loaded-from-disk history behave differently for the same expression.
+- **Continuation prompts** (`... `) are a display-time concern but keep leaking into the data path.
+
+## Intent
+
+One invariant: **history entries are complete, balanced expressions**. An entry is the exact text the user wrote, including their whitespace, minus any display chrome. The `... ` prompt was never typed — it's presentation.
+
+When the user presses `k` to recall, they should see the expression rendered across multiple lines with their original formatting, whether the entry came from the current session or from disk. The behavior must be identical.
+
+## Constraints
+
+- History entries may contain `\n` — this is user data, not a delimiter.
+- `~/.seqlisp_history` file format must support multiline entries.
+- The `... ` prompt is display-only — never stored, never part of the buffer.
+- Single-line editing (the common case) must not regress.
+- Out of scope: j/k line navigation within a multiline buffer (future work per `multiline-repl-history.md`).
+
+## Approach
+
+### 1. Fix history persistence (the data bug)
+
+The file format currently uses `\n` as both the entry delimiter and content character. Fix by escaping or using a different delimiter.
+
+**Option A — Escape newlines**: Store `\n` within entries as `\\n` (literal backslash-n). Unescape on load. Simple, backwards-compatible for single-line entries.
+
+**Option B — Record separator**: Use ASCII `\x1e` (record separator) between entries, `\n` within entries is literal. Cleaner but history file is less human-readable.
+
+**Recommendation: Option A.** It's simpler, the history file stays readable, and single-line entries are unchanged.
+
+### 2. Fix rendering (the presentation bug)
+
+The renderer writes the buffer to the terminal. If the buffer contains `\n`, the terminal needs help:
+
+- Before writing, `\x1b7` saves cursor position and `\x1b[J` clears to end of screen.
+- Replace each `\n` in the buffer with `\n\r... ` when writing — carriage return to column 0, then the visual continuation prompt.
+- After writing, `\x1b8` restores cursor to the start of line 1.
+- Position cursor within the first line based on the buffer cursor position (clamped to first line length).
+
+This keeps the presentation layer (`... `, ANSI escapes) entirely in the render function. The buffer and history never see `... `.
+
+### 3. Data flow
+
+```
+User types line 1 → vim-edit returns "line1"
+REPL accumulates: acc = "line1\n"
+User types line 2 → vim-edit returns "  line2"
+REPL accumulates: acc = "line1\n  line2\n"
+Parens balance → history-add("line1\n  line2")  ← data, no "..."
+                 ↓
+              history-save → "line1\\n  line2\n" in file  ← escaped \n
+                 ↓
+              history-load → "line1\n  line2"  ← unescaped back
+
+User presses k → buffer = "line1\n  line2"
+Renderer shows:
+  ○ > line1
+  ... line2          ← "..." is render-only
+```
+
+## Checkpoints
+
+1. **Persistence round-trip**: Enter multiline expression, quit, restart, press `k` — get the same expression back with original whitespace.
+2. **No `...` in data**: Add `(print history-entry)` debug and confirm no `...` in the stored string.
+3. **Display correct**: Recalled multiline entry shows `... ` at start of continuation lines, no compounding whitespace.
+4. **Single-line unchanged**: Single-line entries work exactly as before (save, load, recall, edit).

--- a/src/vim-line.seq
+++ b/src/vim-line.seq
@@ -23,6 +23,74 @@
 : key-ctrl-c    ( -- Int ) 3 ;
 : key-ctrl-d    ( -- Int ) 4 ;
 
+# Flatten newlines to spaces for editor buffer (single-line editing).
+# History retains the original newlines; this is display/edit only.
+: flatten-newlines ( String -- String )
+  "" swap flatten-newlines-loop ;
+
+: flatten-newlines-loop ( String String -- String )
+  dup string.length 0 i.= if drop else
+    dup 0 1 string.substring
+    dup "\n" string.equal? if drop " " then
+    rot swap string.concat swap
+    dup string.length 1 i.subtract swap 1 rot string.substring
+    flatten-newlines-loop
+  then ;
+
+# Escape newlines for history file storage: \n -> \\n
+# Also escapes backslashes: \ -> \\
+: escape-newlines ( String -- String )
+  "" swap escape-newlines-loop ;
+
+: escape-newlines-loop ( String String -- String )
+  dup string.length 0 i.= if drop else
+    dup 0 1 string.substring
+    dup "\\" string.equal? if
+      drop "\\\\"
+    else dup "\n" string.equal? if
+      drop "\\n"
+    then then
+    rot swap string.concat swap
+    dup string.length 1 i.subtract swap 1 rot string.substring
+    escape-newlines-loop
+  then ;
+
+# Unescape newlines from history file: \\n -> \n, \\\\ -> \\
+: unescape-newlines ( String -- String )
+  "" swap unescape-newlines-loop ;
+
+: unescape-newlines-loop ( String String -- String )
+  # Stack: acc remaining
+  dup string.length 0 i.= if drop else
+    dup string.length 1 i.> if
+      # Check for two-char escape sequences
+      dup 0 2 string.substring
+      dup "\\n" string.equal? if
+        # Replace \\n with newline
+        drop  # acc remaining (drop two-chars)
+        dup string.length 2 i.subtract swap 2 rot string.substring  # acc rest
+        swap "\n" string.concat swap  # (acc+\n) rest
+        unescape-newlines-loop
+      else dup "\\\\" string.equal? if
+        # Replace \\\\ with backslash
+        drop  # acc remaining
+        dup string.length 2 i.subtract swap 2 rot string.substring  # acc rest
+        swap "\\" string.concat swap  # (acc+\\) rest
+        unescape-newlines-loop
+      else
+        # Not an escape — take one char
+        drop  # acc remaining (drop two-chars)
+        dup 0 1 string.substring  # acc remaining char
+        rot swap string.concat swap  # (acc+char) remaining
+        dup string.length 1 i.subtract swap 1 rot string.substring  # (acc+char) rest
+        unescape-newlines-loop
+      then then
+    else
+      # Single char remaining — just append it
+      string.concat  # acc+remaining
+    then
+  then ;
+
 # ============================================
 # EditorState Type
 # ============================================
@@ -266,9 +334,29 @@ union UndoList {
 
 # Add entry to history (prepends to front = newest first)
 # Skips empty strings and duplicates of the most recent entry
+# Strip leading whitespace/newlines from a string
+: string-strip-leading ( String -- String )
+  0 swap string-strip-leading-loop ;
+
+: string-strip-leading-loop ( Int String -- String )
+  # Stack: Pos Str
+  over over string.length i.>= if
+    drop drop ""
+  else
+    dup 2 pick string.char-at  # Pos Str CharCode  (string.char-at wants Str Int)
+    dup 10 i.= over 13 i.= or over 32 i.= or over 9 i.= or if
+      drop swap 1 i.add swap string-strip-leading-loop
+    else
+      # Not whitespace — return Str[Pos..]
+      drop  # Pos Str
+      dup string.length 2 pick i.subtract  # Pos Str RemLen
+      rot swap string.substring  # Str Pos RemLen -> result
+    then
+  then ;
+
 : history-add ( History String -- History )
-  # Strip trailing whitespace/newlines first
-  string-strip-trailing
+  # Strip leading and trailing whitespace/newlines
+  string-strip-leading string-strip-trailing
   # Check if string is empty
   dup string.empty? if
     drop  # Don't add empty strings
@@ -362,7 +450,8 @@ union UndoList {
     nip
   else
     over scar sstring-val  # Get entry string
-    "\n" string.concat     # Add newline
+    escape-newlines        # Escape embedded newlines for file storage
+    "\n" string.concat     # Add record delimiter
     string.concat          # Append to result
     swap scdr swap         # Move to next
     history-to-string-loop
@@ -406,6 +495,7 @@ union UndoList {
       dup string.empty? if
         drop  # Empty, just return History
       else
+        unescape-newlines  # Restore embedded newlines
         sstring swap scons  # NewHistory
       then
     else
@@ -430,6 +520,7 @@ union UndoList {
       swap dup string.empty? if
         drop  # Empty line, skip: History Rest
       else
+        unescape-newlines  # Restore embedded newlines
         sstring  # History Rest SLine
         rot     # Rest SLine History
         scons   # Rest NewHistory  (scons takes SLine History, correct order)
@@ -775,7 +866,6 @@ union UndoList {
 # ============================================
 
 # Render: clear line, show prompt, show buffer, position cursor
-# Original signature - called with extracted values from EdState
 : vim-render ( String String Int Int -- )
   # Stack: Prompt Buffer Cursor Mode
   "\r\x1b[2K" io.write  # Clear line first
@@ -1312,7 +1402,7 @@ union UndoList {
       # Can go up: increment histpos, get history entry
       nip drop  # Drop EdState and Buffer -> History Prompt HistPos
       1 i.add  # History Prompt NewHistPos
-      dup 3 pick swap history-get  # History Prompt NewHistPos HistEntry
+      dup 3 pick swap history-get flatten-newlines  # History Prompt NewHistPos HistEntry
       swap  # History Prompt HistEntry NewHistPos
       vim-edit-with-histpos
     else
@@ -1337,7 +1427,7 @@ union UndoList {
           vim-edit-with-histpos
         else
           # Get history entry at new position
-          dup 3 pick swap history-get  # History Prompt NewHistPos HistEntry
+          dup 3 pick swap history-get flatten-newlines  # History Prompt NewHistPos HistEntry
           swap  # History Prompt HistEntry NewHistPos
           vim-edit-with-histpos
         then


### PR DESCRIPTION
…, untouched

  - History file: escapes \n as \\n — round-trips correctly across restarts
  - Editor buffer: flatten-newlines replaces \n with space on recall — vi motions work correctly on a single line
  - Renderer: original single-line renderer — no bugs

  The multiline display with ...  and indentation is deferred to the full multiline editor project (the 5-7 day design doc). For now, recalled expressions
  are editable single lines with all vi motions working.